### PR TITLE
Output a 500 response code when an exception happens

### DIFF
--- a/dist/twist/Classes/Error.class.php
+++ b/dist/twist/Classes/Error.class.php
@@ -201,6 +201,12 @@
 				self::handleError($arrTags['type_code'],$arrTags['message'],$arrTags['file'],$arrTags['line']);
 			}
 
+			//Output the correct
+			$strHttpProtocol = ("HTTP/1.1" === $_SERVER["SERVER_PROTOCOL"]) ? 'HTTP/1.1' : 'HTTP/1.0';
+
+			//Output a 500 Error response for an exception page (this page should not have a 200 status code)
+			header(sprintf('%s %d Internal Server Error',$strHttpProtocol,500),true,500);
+
             if(TWIST_AJAX_REQUEST){
 
                 header( 'Cache-Control: no-cache, must-revalidate' );


### PR DESCRIPTION
Would hopefully prevent Search Engines from indexing the error message
rather than the intended page.