### PR TITLE
Fixed upload asset group selection

### DIFF
--- a/dist/twist/Core/Controllers/Base.controller.php
+++ b/dist/twist/Core/Controllers/Base.controller.php
@@ -331,7 +331,7 @@
 		 * Get a Route URI var from the route vars, passing in null will return the whole array of route vars.
 		 *
 		 * @param null $strVarKey
-		 * @return array|null
+		 * @return string|array|null
 		 */
         protected function _var($strVarKey = null){
 

--- a/dist/twist/Core/Controllers/Upload.controller.php
+++ b/dist/twist/Core/Controllers/Upload.controller.php
@@ -80,17 +80,27 @@ class Upload extends Base{
 		//Now if the file upload was successful process the asset (if required)
 		if($arrOut['status']){
 
-			$arrDynamicRoute = $this->_route('dynamic');
-
 			//Get the asset group to be used for the upload
+			$arrAssetGroup = array();
 			$intAssetGroup = \Twist::framework()->setting('ASSET_DEFAULT_GROUP');
 
-			if(count($arrDynamicRoute)){
-				if(count($arrDynamicRoute) > 1 && $arrDynamicRoute[0] == 'asset'){
-					$intAssetGroup = \Twist::Asset()->getGroupBySlug($arrDynamicRoute[1]);
-				}elseif($arrDynamicRoute[0] !== 'asset'){
-					$intAssetGroup = \Twist::Asset()->getGroupBySlug($arrDynamicRoute[0]);
+			//Allow for a URI to be registered such as: Twist::Route()->upload('/account/upload/{function}/{asset_group}');
+			if($this->_var('asset_group') != null && $this->_var('asset_group') != ''){
+				$arrAssetGroup = \Twist::Asset()->getGroupBySlug($this->_var('asset_group'));
+			}else{
+				$arrDynamicRoute = $this->_route('dynamic');
+
+				if(count($arrDynamicRoute)){
+					if(count($arrDynamicRoute) > 1 && $arrDynamicRoute[0] == 'asset'){
+						$arrAssetGroup = \Twist::Asset()->getGroupBySlug($arrDynamicRoute[1]);
+					}elseif($arrDynamicRoute[0] !== 'asset'){
+						$arrAssetGroup = \Twist::Asset()->getGroupBySlug($arrDynamicRoute[0]);
+					}
 				}
+			}
+
+			if(count($arrAssetGroup)){
+				$intAssetGroup = $arrAssetGroup['id'];
 			}
 
 			$intAssetID = \Twist::Asset()->add($arrOut['file']['path'],$intAssetGroup);


### PR DESCRIPTION
Now you can setup a URI such as
Twist::Route()->upload('/account/upload/{function}/{asset_group}'); for
the asset uploader. Also the asset group part of the uploader was
broken (Now Fixed)